### PR TITLE
Add ability to verify Mocked Component was placed in DOM

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,17 @@ this.el = ReactHelper.render(
 ); // this will render an empty div
 ```
 
+**mockComponentWithClassName(Component, ClassName)**
+
+Any subequent rendering of the provided component will render a `div` with the provided className instead of executing its real `render` function.
+
+```js
+ReactHelper.mockComponent(DummyComponent, "example");
+this.el = ReactHelper.render(
+  <DummyComponent />
+); // this will render <div class="example" />
+```
+
 **setup()**
 
 This function should be called before any other ReactHelper methods are. In this scaffold, it is done globally in `spec/helpers/spec_helper.js`.

--- a/spec/helpers/react-helper.js
+++ b/spec/helpers/react-helper.js
@@ -27,14 +27,29 @@ class ReactHelper {
     return this._el;
   }
 
-  mockComponent(component) {
+  _addMockForComponent(component) {
     this._mockedComponents[component.name] = {
       component: component,
       renderFn: component.prototype.render
     };
+  }
+
+  mockComponent(component) {
+    this._addMockForComponent(component);  
 
     component.prototype.render = function mockRender() {
       return (<div/>);
+    };
+  }
+
+  mockComponentWithClassName(component, className) {
+    this._addMockForComponent(component);
+    
+    component.state = { className: className };
+
+    component.prototype.render = function mockRender() {
+      this.state = {className: className}
+      return (<div className={this.state.className}/>);
     };
   }
 }

--- a/spec/lib/react_helper_spec.js
+++ b/spec/lib/react_helper_spec.js
@@ -1,19 +1,56 @@
 var React = require('react');
 var ReactHelper = require('../helpers/react-helper');
 
+const initialClassName = 'initial-class-name';
+const mockComponentWithClassName = 'mocked-component-class-name';
+
 class DummyComponent extends React.Component {
+  constructor() {
+    super();
+    this.state = {className: initialClassName};
+  }
+
   render() {
     return (
-      <div>I have some contents</div>
+      <div className={this.state.className}>I have some contents</div>
     );
   }
 }
 
 describe('ReactHelper', function() {
-  describe('preventing test pollution when rendering', function() {
+  describe('-mockComponent', function() {
+    describe('preventing test pollution when rendering', function() {
+      describe('a mocked component (before an unmocked test)', function() {
+        beforeEach(function() {
+          ReactHelper.mockComponent(DummyComponent);
+          this.el = ReactHelper.render(
+            <DummyComponent />
+          );
+        });
+
+        it('is rendered into the DOM without any children', function() {
+          expect(this.el.textContent).toEqual('');
+        });
+      });
+
+      describe('an unmocked component (after a mocked test)', function() {
+        beforeEach(function() {
+          this.el = ReactHelper.render(
+            <DummyComponent />
+          );
+        });
+
+        it('is rendered into the DOM normally', function() {
+          expect(this.el.textContent).toEqual('I have some contents');
+        });
+      });
+    });
+  });
+
+  describe('-mockComponentWithClassName', function() {
     describe('a mocked component (before an unmocked test)', function() {
       beforeEach(function() {
-        ReactHelper.mockComponent(DummyComponent);
+        ReactHelper.mockComponentWithClassName(DummyComponent, mockComponentWithClassName);
         this.el = ReactHelper.render(
           <DummyComponent />
         );
@@ -21,6 +58,11 @@ describe('ReactHelper', function() {
 
       it('is rendered into the DOM without any children', function() {
         expect(this.el.textContent).toEqual('');
+      });
+
+     it('is rendered into the DOM with a className', function() {
+        expect(this.el.getElementsByClassName(mockComponentWithClassName).length).toEqual(1);
+        expect(this.el.getElementsByClassName(initialClassName).length).toEqual(0);
       });
     });
 
@@ -33,6 +75,11 @@ describe('ReactHelper', function() {
 
       it('is rendered into the DOM normally', function() {
         expect(this.el.textContent).toEqual('I have some contents');
+      });
+
+      it('is rendered into the DOM with initial-class-name', function() {
+        expect(this.el.getElementsByClassName(mockComponentWithClassName).length).toEqual(0);
+        expect(this.el.getElementsByClassName(initialClassName).length).toEqual(1);
       });
     });
   });

--- a/spec/lib/react_helper_spec.js
+++ b/spec/lib/react_helper_spec.js
@@ -48,38 +48,40 @@ describe('ReactHelper', function() {
   });
 
   describe('-mockComponentWithClassName', function() {
-    describe('a mocked component (before an unmocked test)', function() {
-      beforeEach(function() {
-        ReactHelper.mockComponentWithClassName(DummyComponent, mockComponentWithClassName);
-        this.el = ReactHelper.render(
-          <DummyComponent />
-        );
+    describe('preventing test pollution when rendering', function() {
+      describe('a mocked component (before an unmocked test)', function() {
+        beforeEach(function() {
+          ReactHelper.mockComponentWithClassName(DummyComponent, mockComponentWithClassName);
+          this.el = ReactHelper.render(
+            <DummyComponent />
+          );
+        });
+
+        it('is rendered into the DOM without any children', function() {
+          expect(this.el.textContent).toEqual('');
+        });
+
+       it('is rendered into the DOM with a className', function() {
+          expect(this.el.getElementsByClassName(mockComponentWithClassName).length).toEqual(1);
+          expect(this.el.getElementsByClassName(initialClassName).length).toEqual(0);
+        });
       });
 
-      it('is rendered into the DOM without any children', function() {
-        expect(this.el.textContent).toEqual('');
-      });
+      describe('an unmocked component (after a mocked test)', function() {
+        beforeEach(function() {
+          this.el = ReactHelper.render(
+            <DummyComponent />
+          );
+        });
 
-     it('is rendered into the DOM with a className', function() {
-        expect(this.el.getElementsByClassName(mockComponentWithClassName).length).toEqual(1);
-        expect(this.el.getElementsByClassName(initialClassName).length).toEqual(0);
-      });
-    });
+        it('is rendered into the DOM normally', function() {
+          expect(this.el.textContent).toEqual('I have some contents');
+        });
 
-    describe('an unmocked component (after a mocked test)', function() {
-      beforeEach(function() {
-        this.el = ReactHelper.render(
-          <DummyComponent />
-        );
-      });
-
-      it('is rendered into the DOM normally', function() {
-        expect(this.el.textContent).toEqual('I have some contents');
-      });
-
-      it('is rendered into the DOM with initial-class-name', function() {
-        expect(this.el.getElementsByClassName(mockComponentWithClassName).length).toEqual(0);
-        expect(this.el.getElementsByClassName(initialClassName).length).toEqual(1);
+        it('is rendered into the DOM with initial-class-name', function() {
+          expect(this.el.getElementsByClassName(mockComponentWithClassName).length).toEqual(0);
+          expect(this.el.getElementsByClassName(initialClassName).length).toEqual(1);
+        });
       });
     });
   });


### PR DESCRIPTION
I needed the ability to verify that a child component was rendered by it's parent. So I added the ability to populate the empty div's className attribute. 

There is some duplication in the spec. However there doesn't seem to be an equivalent to shared_examples in Jasmine. What do you think would be the best way to reconcile this?
